### PR TITLE
Add symbolized disassembly support

### DIFF
--- a/src/xauto_cmd.cpp
+++ b/src/xauto_cmd.cpp
@@ -531,6 +531,7 @@ void dbg_is_valid_read_ptr(msgpack::object root, msgpack::sbuffer& response_buff
 void disassemble_at(msgpack::object root, msgpack::sbuffer& response_buffer) {
     size_t addr;
     DISASM_INSTR instr;
+    char symbolized_disassembly[GUI_MAX_DISASSEMBLY_SIZE];
 
     if(root.via.array.size < 2 || root.via.array.ptr[1].type != msgpack::type::POSITIVE_INTEGER) {
         msgpack::pack(response_buffer, false);
@@ -539,8 +540,15 @@ void disassemble_at(msgpack::object root, msgpack::sbuffer& response_buffer) {
 
     root.via.array.ptr[1].convert(addr);
     DbgDisasmAt(addr, &instr);
+
+    std::string symbolized_instruction = std::string(instr.instruction);
+    if(GuiGetDisassembly(addr, symbolized_disassembly)) {
+        symbolized_instruction = std::string(symbolized_disassembly);
+    }
+
     msgpack::pack(response_buffer, DisasmTup(
         std::string(instr.instruction),
+        symbolized_instruction,
         instr.argcount,
         instr.instr_size,
         instr.type,

--- a/src/xauto_cmd.h
+++ b/src/xauto_cmd.h
@@ -67,7 +67,7 @@ void dbg_write_setting_uint(msgpack::object root, msgpack::sbuffer& response_buf
 void dbg_is_valid_read_ptr(msgpack::object root, msgpack::sbuffer& response_buffer);
 
 typedef std::tuple<std::string, size_t, size_t, size_t, size_t, size_t> DisasmArgTup;
-typedef std::tuple<std::string, size_t, size_t, size_t, std::array<DisasmArgTup, 3>> DisasmTup;
+typedef std::tuple<std::string, std::string, size_t, size_t, size_t, std::array<DisasmArgTup, 3>> DisasmTup;
 void disassemble_at(msgpack::object root, msgpack::sbuffer& response_buffer);
 void assemble_at(msgpack::object root, msgpack::sbuffer& response_buffer);
 


### PR DESCRIPTION
Add symbolized disassembly text to DisasmTup

Consumers of disassemble_at currently receive the raw instruction text, which omit useful symbol information in x64dbg. Returning both raw and symbolized forms makes the API more useful for automation, MCP integrations, and human-readable analysis output.

Changes:

* Use GuiGetDisassembly to retrieve x64dbg's symbolized disassembly text
* Add a symbolized instruction string to DisasmTup